### PR TITLE
Expand profile fields

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,7 +16,23 @@ function generateToken(user) {
 
 // Auth Routes
 app.post('/api/auth/register', async (req, res) => {
-  const { email, password, role } = req.body;
+  const {
+    email,
+    password,
+    role,
+    currentLevel,
+    targetLevel,
+    learningPreferences,
+    availability,
+    personalityTraits,
+    learningGoals,
+    budgetRange,
+    teachingLevels,
+    specializations,
+    teachingMethods,
+    teachingPersonality,
+    hourlyRate,
+  } = req.body;
   try {
     const hashed = await bcrypt.hash(password, 10);
     const user = await prisma.user.create({
@@ -24,10 +40,30 @@ app.post('/api/auth/register', async (req, res) => {
     });
     if (role === 'TUTOR') {
       await prisma.tutorProfile.create({
-        data: { userId: user.id, qualification: '', availability: '' },
+        data: {
+          userId: user.id,
+          qualification: '',
+          availability: availability || '',
+          teachingLevels,
+          specializations,
+          teachingMethods,
+          teachingPersonality,
+          hourlyRate,
+        },
       });
     } else {
-      await prisma.studentProfile.create({ data: { userId: user.id } });
+      await prisma.studentProfile.create({
+        data: {
+          userId: user.id,
+          currentLevel,
+          targetLevel,
+          learningPreferences,
+          availability,
+          personalityTraits,
+          learningGoals,
+          budgetRange,
+        },
+      });
     }
     const token = generateToken(user);
     res.json({ token });
@@ -64,9 +100,29 @@ app.get('/api/tutors/:id', async (req, res) => {
 });
 
 app.post('/api/tutors', async (req, res) => {
-  const { userId, qualification, availability } = req.body;
+  const {
+    userId,
+    qualification,
+    availability,
+    teachingLevels,
+    specializations,
+    teachingMethods,
+    teachingPersonality,
+    hourlyRate,
+  } = req.body;
   try {
-    const tutor = await prisma.tutorProfile.create({ data: { userId, qualification, availability } });
+    const tutor = await prisma.tutorProfile.create({
+      data: {
+        userId,
+        qualification,
+        availability,
+        teachingLevels,
+        specializations,
+        teachingMethods,
+        teachingPersonality,
+        hourlyRate,
+      },
+    });
     res.json(tutor);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -75,9 +131,28 @@ app.post('/api/tutors', async (req, res) => {
 
 app.put('/api/tutors/:id', async (req, res) => {
   const id = parseInt(req.params.id);
-  const { qualification, availability } = req.body;
+  const {
+    qualification,
+    availability,
+    teachingLevels,
+    specializations,
+    teachingMethods,
+    teachingPersonality,
+    hourlyRate,
+  } = req.body;
   try {
-    const tutor = await prisma.tutorProfile.update({ where: { id }, data: { qualification, availability } });
+    const tutor = await prisma.tutorProfile.update({
+      where: { id },
+      data: {
+        qualification,
+        availability,
+        teachingLevels,
+        specializations,
+        teachingMethods,
+        teachingPersonality,
+        hourlyRate,
+      },
+    });
     res.json(tutor);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/prisma/migrations/20250716014054-add-profile-fields/migration.sql
+++ b/server/prisma/migrations/20250716014054-add-profile-fields/migration.sql
@@ -1,0 +1,16 @@
+-- AlterTable
+ALTER TABLE "TutorProfile" ADD COLUMN     "hourlyRate" INTEGER,
+ADD COLUMN     "specializations" TEXT,
+ADD COLUMN     "teachingLevels" TEXT,
+ADD COLUMN     "teachingMethods" TEXT,
+ADD COLUMN     "teachingPersonality" TEXT;
+
+-- AlterTable
+ALTER TABLE "StudentProfile" ADD COLUMN     "availability" TEXT,
+ADD COLUMN     "budgetRange" TEXT,
+ADD COLUMN     "currentLevel" TEXT,
+ADD COLUMN     "learningGoals" TEXT,
+ADD COLUMN     "learningPreferences" TEXT,
+ADD COLUMN     "personalityTraits" TEXT,
+ADD COLUMN     "targetLevel" TEXT;
+

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -30,6 +30,11 @@ model TutorProfile {
   userId        Int    @unique
   qualification String
   availability  String
+  teachingLevels      String?
+  specializations     String?
+  teachingMethods     String?
+  teachingPersonality String?
+  hourlyRate          Int?
   bookings      Booking[]
 }
 
@@ -37,6 +42,13 @@ model StudentProfile {
   id      Int  @id @default(autoincrement())
   user    User @relation(fields: [userId], references: [id])
   userId  Int  @unique
+  currentLevel       String?
+  targetLevel        String?
+  learningPreferences String?
+  availability        String?
+  personalityTraits   String?
+  learningGoals       String?
+  budgetRange         String?
   bookings Booking[]
 }
 


### PR DESCRIPTION
## Summary
- expand `StudentProfile` and `TutorProfile` models with additional details
- generate a migration for the new fields
- update auth and tutor routes to handle the new data

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6877025cc7ec83228526be25df055dd6